### PR TITLE
Fix string getter and enumeration of parts

### DIFF
--- a/src/KRPC.jl
+++ b/src/KRPC.jl
@@ -43,6 +43,7 @@ include("streams.jl")
 include("codegen.jl")
 if isfile("generated.jl")
 	include("generated.jl")
+    include("aftertypes.jl")
 end
 
 struct AddStream_Phantom <: Request{:KRPC, :AddStream, kRPCTypes.kStream}

--- a/src/KRPC.jl
+++ b/src/KRPC.jl
@@ -43,7 +43,7 @@ include("streams.jl")
 include("codegen.jl")
 if isfile("generated.jl")
 	include("generated.jl")
-    include("aftertypes.jl")
+	include("aftertypes.jl")
 end
 
 struct AddStream_Phantom <: Request{:KRPC, :AddStream, kRPCTypes.kStream}

--- a/src/aftertypes.jl
+++ b/src/aftertypes.jl
@@ -1,0 +1,10 @@
+import KRPC.Interface.SpaceCenter.RemoteTypes as RemoteTypes
+
+function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Type{RemoteTypes.Part})
+    res = ProtoBuf.read_varint(PipeBuffer(value), Int64)
+    if res == 0
+        return Nothing()
+    else
+        return RemoteTypes.Part(conn, res)
+    end
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -105,7 +105,7 @@ function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Nothing)
     return Nothing()
 end
 
-function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Type{AbstractString})
+function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Union{Type{AbstractString}, Type{String}})
     return ProtoBuf.read_string(PipeBuffer(value))
 end
 
@@ -128,7 +128,7 @@ end
 
 function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Type{Array{T,1}}) where T
     res = readproto(PipeBuffer(value), krpc.schema.List())
-    return T[getJuliaValue(item,T) for item in res.items]
+    return T[getJuliaValue(conn,item,T) for item in res.items]
 end
 
 function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Type{T}) where T <: (Tuple{Vararg{T,N} where T where N})


### PR DESCRIPTION
This PR addresses two problems I found so far: getting string, and getting "Parts".

I am new to Julia, and I do not really understand what is going on behind the scenes, but here is what I did to fix the problem.

## Problem 1: failure to get strings

The problem is caused from `types.jl:108`, where Julia is asking for String, but there is no method for getJuliaValue for String. There is one for AbstractString, though. So I added it to existing AbstractString.

```
function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Union{Type{AbstractString}, Type{String}})
    return ProtoBuf.read_string(PipeBuffer(value))
end
```

This will enable the user to use commands like Title(part), Name(part).

## Problem 2: failure to get parts

I am expecting that similar problems will pop up more as I try to access more of the KRPC entities. I was not able to get parts of the vessel by using Parts(vessel), where vessel is `KRPC.Interface.SpaceCenter.RemoteTypes.Vessel`.

The solution to this problem is twofold:

`types.jl:131` has call for getJuliaValue, but omits argument for conn. Adding conn fixes this problem.
I notice that line 98 may also have a similar problem, but I did not touch it since I didn't need to use this method (yet)
```
function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Type{Array{T,1}}) where T
    res = readproto(PipeBuffer(value), krpc.schema.List())
    return T[getJuliaValue(conn,item,T) for item in res.items]
end
```

And then there should be a getJuliaValue method for the `RemoteTypes.Part` type itself! This is the part where I am writing something I don't understand.

in a brand new file, which I called `aftertypes.jl`, I created a new method that will return the correct part.
because it references types added in `generated.jl`, I cannot add this method in `types.jl`, hence the new file.
I took the lines from other method that seems to do something similar, and splashed a `Part` into it.
This code might make no sense! If you see that something is off, please patch that in if you are merging this PR.

```
import KRPC.Interface.SpaceCenter.RemoteTypes as RemoteTypes

function getJuliaValue(conn, value::Array{UInt8, 1}, rtype::Type{RemoteTypes.Part})
    res = ProtoBuf.read_varint(PipeBuffer(value), Int64)
    if res == 0
        return Nothing()
    else
        return RemoteTypes.Part(conn, res)
    end
end
```

I am expecting that similar patches may be needed to extend kRPC to julia even more.
Let me know if these kind of PRs are welcome.

/Rhahi