### PR TITLE
Enable asynchronous usage of KRPC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,13 @@ LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.6"
 LightXML = "^0.9"
 MacroTools = "^0.5"
 ProtoBuf = "^0.11"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/KRPC.jl
+++ b/src/KRPC.jl
@@ -32,6 +32,14 @@ mutable struct KRPCConnection
     one_to_many::Dict{UInt64, Array{UUID, 1}}
     listeners::Dict{UUID, Listener}
     active::Channel
+    semaphore::Base.Semaphore
+
+    function KRPCConnection(conn::TCPSocket, stream_conn::TCPSocket, identifier::Array{UInt8, 1}, active::Channel)
+        new(
+            conn, stream_conn, identifier,
+            Nothing(), Dict{UInt8, Array{UUID, 1}}(), Dict{UUID, Listener}(), active, Base.Semaphore(1)
+        )
+    end
 end
 
 function Base.show(io::IO, conn::KRPCConnection) 

--- a/src/KRPC.jl
+++ b/src/KRPC.jl
@@ -2,6 +2,7 @@ module KRPC
 using Sockets
 using ProtoBuf
 using LightXML
+using UUIDs
 import MacroTools
 
 include("proto/krpc.jl")
@@ -16,6 +17,7 @@ struct Listener{T}
 	connection::T
 	current_value
 	channel::Channel
+    uuid::UUID
 end
 
 """
@@ -27,7 +29,8 @@ mutable struct KRPCConnection
     identifier::Array{UInt8, 1}
 
     str_listener::Union{Nothing, Task}
-    listeners::Dict{UInt64, Listener}
+    one_to_many::Dict{UInt64, Array{UUID, 1}}
+    listeners::Dict{UUID, Listener}
     active::Channel
 end
 

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -78,7 +78,7 @@ function kerbal_connect(client_name::String, host::String="localhost", port::Int
     connect_or_error(str_conn, krpc.schema.ConnectionRequest(client_identifier=resp.client_identifier,_type=krpc.schema.ConnectionRequest_Type.STREAM))
 
     active = Channel(0)
-    conn = KRPCConnection(conn, str_conn, resp.client_identifier, Nothing(), Dict{UInt8, Listener}(), active)
+    conn = KRPCConnection(conn, str_conn, resp.client_identifier, Nothing(), Dict{UInt8, Array{UUID, 1}}(), Dict{UUID, Listener}(), active)
     conn.str_listener = @async stream_listener(conn)
     bind(active, conn.str_listener)
 

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -78,7 +78,7 @@ function kerbal_connect(client_name::String, host::String="localhost", port::Int
     connect_or_error(str_conn, krpc.schema.ConnectionRequest(client_identifier=resp.client_identifier,_type=krpc.schema.ConnectionRequest_Type.STREAM))
 
     active = Channel(0)
-    conn = KRPCConnection(conn, str_conn, resp.client_identifier, Nothing(), Dict{UInt8, Array{UUID, 1}}(), Dict{UUID, Listener}(), active)
+    conn = KRPCConnection(conn, str_conn, resp.client_identifier, active)
     conn.str_listener = @async stream_listener(conn)
     bind(active, conn.str_listener)
 

--- a/src/raw.jl
+++ b/src/raw.jl
@@ -28,6 +28,7 @@ function RecvRawProto(inp::IO)
 end
 
 function SendBiMessage(conn::KRPCConnection, req::KRPC.krpc.schema.Request)
+    Base.acquire(conn.semaphore)
     iob = PipeBuffer()
     SendRawProto(conn.conn, req)
     res = readproto(RecvRawProto(conn.conn), krpc.schema.Response())
@@ -35,6 +36,7 @@ function SendBiMessage(conn::KRPCConnection, req::KRPC.krpc.schema.Request)
     if hasproperty(res, :error)
         throw(make_error(res.error))
     end
+    Base.release(conn.semaphore)
     return res
 end
 


### PR DESCRIPTION
This PR resolves two problems regarding async usage of KRPC.

### Fix handling of parallel stream

First problem is that KRPC.jl previously did not allow parallel streaming. The problem comes from `add_stream` function:

1. User calls add_stream
2. `handles` are created: `handles = kerbal(conn, ((AddStream_Phantom.(calls, true))..., ))`
3. `listener` is created `listener = Listener(request_map, conn, default_value, out)`
4. the listener is remembered within a dictionary within `KRPCConnection`: `setindex!.((conn.listeners, ), (listener, ), getproperty.(handles, :id))`

Number 4 is where the problem occurs. Because the handle.id is unique for each type of stream (i.e., two parallel calls for universal time will have the same id), as soon as the second stream is established, the first one is forgotten and will never produce value (as the pump will not find it anymore)

This PR addresses the problem by assigning a unique identifier (instead of using handle id) whenever a new stream is created, resulting in this sequence:

1. Assume that there was already a stream watching VAR1.
2. User asks for a stream, watching for VAR1 and VAR2.
3. a new UID is generated for this pair: `uuid = uuid4()`
4. KRPCConnection remembers this listener with UID as a key: `conn.listeners[uuid] = listener`

So far so good, but this requires a further step because of handling of closing the streams.
When closing stream for listener (VAR1 + VAR2), we can't just close the connection just yet. That's because streams are closed using the handle ID (`push!(req, RemoveStream_Phantom(id))`. When a connection for VAR1+VAR2 is removed, another stream that watches VAR1 will also be unavailable. Therefore we must remember that VAR1 should stay open until another listener for VAR1 wants to close, too.

5. Create a one-to-many relationship between ID of the variable being watched, and UIDs.
6. When a listener (associated with UID) wants to close, instead of closing it immediately, just remove it from the ID list.
7. If the removed UID from an ID list is the final one, we are finally safe to remove the actual stream from KRPC.

Note: This will introduce a new dependency for Julia package `UUIDs`. Alternatively, having a mutable global (or in KRPCConnection) variable that always increments can also solve without introducing such dependency. If you prefer to have something like that, I can make a new PR with that.

### Fix race condition when calling SendBiMessage

This problem will cause KRPC.jl to hang and eventually crash when a remote call is produced while one has not been completed. It is easier triggered if the user creates multiple async calls, each calling for some Kerbal values or commands. Initially, I attempted to fix it by wrapping the function with sync-async block, but this made no effect. I instead added a semaphore within KRPCConnection, so that SendBiMessage can synchronize using that.
