### PR TITLE
Various fixes for KRPC.jl

### DIFF
--- a/src/raw.jl
+++ b/src/raw.jl
@@ -31,7 +31,6 @@ function SendBiMessage(conn::KRPCConnection, req::KRPC.krpc.schema.Request)
     Base.acquire(conn.semaphore)
     res = nothing
     try
-        iob = PipeBuffer()
         SendRawProto(conn.conn, req)
         res = readproto(RecvRawProto(conn.conn), krpc.schema.Response())
 

--- a/src/streams.jl
+++ b/src/streams.jl
@@ -76,7 +76,7 @@ Base.iterate(channel::Listener, state) = iterate(channel.channel, state)
 function Base.close(channel::Listener)
     req = Request[]
     for id in keys(channel.streams)
-        if !(id in keys(channel.streams))
+        if !(id in keys(channel.connection.one_to_many))
             error("Attempted to remove unbound stream. Check if the stream has already been removed.")
         end
         lmap = channel.connection.one_to_many[id]

--- a/src/streams.jl
+++ b/src/streams.jl
@@ -77,7 +77,9 @@ function Base.close(channel::Listener)
     req = Request[]
     for id in keys(channel.streams)
         if !(id in keys(channel.connection.one_to_many))
-            error("Attempted to remove unbound stream. Check if the stream has already been removed.")
+            # there is no such ID to delete here. this shouldn't happen, but it's not critical.
+            @warn "Attempted to remove unbound stream $id. Check if the stream has already been removed."
+            continue
         end
         lmap = channel.connection.one_to_many[id]
         index = findfirst(x -> x==channel.uuid, lmap)

--- a/src/streams.jl
+++ b/src/streams.jl
@@ -89,6 +89,7 @@ function Base.close(channel::Listener)
     end
     delete!(channel.connection.listeners, channel.uuid)
     kerbal(channel.connection, (req..., ))
+    close(channel.channel)
 end
 
 function update_value(listener::Listener, stream::UInt64, value)

--- a/src/types.jl
+++ b/src/types.jl
@@ -69,7 +69,7 @@ end
 
 function getWireValue(arg::Tuple)
     opb = PipeBuffer()
-    ProtoBuf.writeproto(opb, krpc.schema.Tuple_(items=convert(Array{Array{UInt8,1},1}, collect(map(getWireValue, arg)))))
+    ProtoBuf.writeproto(opb, krpc.schema.Tuple(items=convert(Array{Array{UInt8,1},1}, collect(map(getWireValue, arg)))))
     return readavailable(opb)
 end
 


### PR DESCRIPTION
Hello,

I am not sure if you like to receive PR with one PR doing one thing each, or receive fixes all at once, so I collected my accumulated fixes in one PR. If you prefer the other way around, we can close this and try again.

Here are the list of changes:

## Minor changes
* 2cc9c2e (HEAD -> develop, fork/develop) doc: add helpful inline comments for close(Listener)
this contains simple commentaries to help myself. Maybe you don't want it? We can drop this commit.

* 4ddc0df refactor: downgrade error() in close(Listener) to warning
I thought throwing an error here is abit overkill, although having a request to closed stream might indicate that something else is wrong and having come "de-sync" issues. Let me know if you think this is a bad idea.

* 17fd742 fix: remove unused PipeBuffer
Probably a leftover from past code?

## Fixes
* a13a707 fix: remove undescore in Tuple_ from types
I think this is the one you told me in KRPC discord..

* 1942084 fix: use one_to_many to checking unbound stream removal
This is a fix for a regression I introduced. I was not properly handling closing of streams.

* 47344ab fix: close the Julia channel when closing listener
This signals the consumer that the channel is closed and there is no point in waiting anymore.

* ff8e994 fix: use try-finally to release semaphore
I pointed this out after you merged my previous fix for raw.jl, and it's finally getting patched.
