### PR TITLE
Cumulative bug fixes

### DIFF
--- a/src/KRPC.jl
+++ b/src/KRPC.jl
@@ -31,10 +31,10 @@ mutable struct KRPCConnection
     str_listener::Union{Nothing, Task}
     one_to_many::Dict{UInt64, Array{UUID, 1}}
     listeners::Dict{UUID, Listener}
-    active::Channel
+    active::Channel{Bool}
     semaphore::Base.Semaphore
 
-    function KRPCConnection(conn::TCPSocket, stream_conn::TCPSocket, identifier::Array{UInt8, 1}, active::Channel)
+    function KRPCConnection(conn::TCPSocket, stream_conn::TCPSocket, identifier::Array{UInt8, 1}, active::Channel{Bool})
         new(
             conn, stream_conn, identifier,
             Nothing(), Dict{UInt8, Array{UUID, 1}}(), Dict{UUID, Listener}(), active, Base.Semaphore(1)

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -350,6 +350,7 @@ function generateHelpers(info::krpc.schema.Services, status::krpc.schema.Status)
             import ....kerbal;
             import ....KRPCConnection;
             import ....Request;
+            import ....getJuliaValue;
             import ..RemoteTypes; 
             $((:(import ...($(Symbol(req)))) for req in ctx.needed)...);
             $((:(import ...($(enum[1])).($(enum[2]))) for enum in ctx.neededEnums)...); 

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -213,7 +213,7 @@ end
 
 function make_param(argname, param, ctx)
     if !isnothing(param.default_value) && length(param.default_value) > 0
-        return Expr(:kw, Expr(:(::), argname, kRPCToJuliaType(param._type, ctx)), :(getJuliaValue(this.conn, $(param.default_value), $(kRPCToJuliaType(param._type, ctx)))))
+        return Expr(:kw, Expr(:(::), argname, kRPCToJuliaType(param._type, ctx)), :(getJuliaValue(conn.conn, $(param.default_value), $(kRPCToJuliaType(param._type, ctx)))))
     else
         return :($(argname)::$(kRPCToJuliaType(param._type, ctx)))
     end

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -77,7 +77,7 @@ function kerbal_connect(client_name::String, host::String="localhost", port::Int
     resp = connect_or_error(conn, krpc.schema.ConnectionRequest(client_name=client_name,_type=krpc.schema.ConnectionRequest_Type.RPC))
     connect_or_error(str_conn, krpc.schema.ConnectionRequest(client_identifier=resp.client_identifier,_type=krpc.schema.ConnectionRequest_Type.STREAM))
 
-    active = Channel(0)
+    active = Channel{Bool}(0)
     conn = KRPCConnection(conn, str_conn, resp.client_identifier, active)
     conn.str_listener = @async stream_listener(conn)
     bind(active, conn.str_listener)

--- a/src/proto/krpc_pb.jl
+++ b/src/proto/krpc_pb.jl
@@ -18,8 +18,8 @@ mutable struct ConnectionRequest <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -68,8 +68,8 @@ mutable struct ConnectionResponse <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -111,8 +111,8 @@ mutable struct Argument <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -152,8 +152,8 @@ mutable struct ProcedureCall <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -200,8 +200,8 @@ mutable struct Request <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -239,8 +239,8 @@ mutable struct Error <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -284,8 +284,8 @@ mutable struct ProcedureResult <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -325,8 +325,8 @@ mutable struct Response <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -366,8 +366,8 @@ mutable struct StreamResult <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -407,8 +407,8 @@ mutable struct StreamUpdate <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -446,8 +446,8 @@ mutable struct Class <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -487,8 +487,8 @@ mutable struct EnumerationValue <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -530,8 +530,8 @@ mutable struct Enumeration <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -573,8 +573,8 @@ mutable struct Exception <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -638,8 +638,8 @@ mutable struct _Type <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -683,8 +683,8 @@ mutable struct Parameter <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -735,8 +735,8 @@ mutable struct Procedure <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -786,8 +786,8 @@ mutable struct Service <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -835,8 +835,8 @@ mutable struct Services <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -874,8 +874,8 @@ mutable struct Tuple <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -913,8 +913,8 @@ mutable struct List <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -952,8 +952,8 @@ mutable struct _Set <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -991,8 +991,8 @@ mutable struct DictionaryEntry <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -1032,8 +1032,8 @@ mutable struct Dictionary <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -1071,8 +1071,8 @@ mutable struct Stream <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -1110,8 +1110,8 @@ mutable struct Event <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -1149,8 +1149,8 @@ mutable struct Status <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -1224,8 +1224,8 @@ mutable struct MultiplexedRequest <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end
@@ -1265,8 +1265,8 @@ mutable struct MultiplexedResponse <: ProtoType
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
             fldname, fldval = nv
-            fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            fldtype = symdict[fldname].jtyp
             if fldval !== nothing
                 values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
             end

--- a/src/raw.jl
+++ b/src/raw.jl
@@ -35,7 +35,7 @@ function SendBiMessage(conn::KRPCConnection, req::KRPC.krpc.schema.Request)
         res = readproto(RecvRawProto(conn.conn), krpc.schema.Response())
 
         if hasproperty(res, :error)
-            throw(make_error(res.error))
+            throw(res.error)
         end
     finally
         Base.release(conn.semaphore)
@@ -47,10 +47,10 @@ function GetInfo(conn::KRPCConnection)
     rv = SendBiMessage(conn, 
         krpc.schema.Request(calls=[krpc.schema.ProcedureCall(service="KRPC", procedure="GetStatus")]))
     if hasfield(rv, :error)
-        throw(make_error(rv.error))
+        throw(rv.error)
     end
     if hasfield(rv.results[1], :error)
-        throw(make_error(rv.results[1].error))
+        throw(rv.results[1].error)
     end
     iob = PipeBuffer()
     write(iob, rv.results[1].value)
@@ -61,10 +61,10 @@ function GetServices(conn::KRPCConnection)
     rv = SendBiMessage(conn, 
         krpc.schema.Request(calls=[krpc.schema.ProcedureCall(service="KRPC", procedure="GetServices")]))
     if hasproperty(rv, :error)
-        throw(make_error(rv.error))
+        throw(rv.error)
     end
     if hasproperty(rv.results[1], :error)
-        throw(make_error(rv.results[1].error))
+        throw(rv.results[1].error)
     end
     iob = PipeBuffer()
     write(iob, rv.results[1].value)

--- a/src/raw.jl
+++ b/src/raw.jl
@@ -35,7 +35,7 @@ function SendBiMessage(conn::KRPCConnection, req::KRPC.krpc.schema.Request)
         res = readproto(RecvRawProto(conn.conn), krpc.schema.Response())
 
         if hasproperty(res, :error)
-            throw(res.error)
+            error(res.error)
         end
     finally
         Base.release(conn.semaphore)
@@ -47,10 +47,10 @@ function GetInfo(conn::KRPCConnection)
     rv = SendBiMessage(conn, 
         krpc.schema.Request(calls=[krpc.schema.ProcedureCall(service="KRPC", procedure="GetStatus")]))
     if hasfield(rv, :error)
-        throw(rv.error)
+        error(rv.error)
     end
     if hasfield(rv.results[1], :error)
-        throw(rv.results[1].error)
+        error(rv.results[1].error)
     end
     iob = PipeBuffer()
     write(iob, rv.results[1].value)
@@ -61,10 +61,10 @@ function GetServices(conn::KRPCConnection)
     rv = SendBiMessage(conn, 
         krpc.schema.Request(calls=[krpc.schema.ProcedureCall(service="KRPC", procedure="GetServices")]))
     if hasproperty(rv, :error)
-        throw(rv.error)
+        error(rv.error)
     end
     if hasproperty(rv.results[1], :error)
-        throw(rv.results[1].error)
+        error(rv.results[1].error)
     end
     iob = PipeBuffer()
     write(iob, rv.results[1].value)

--- a/src/types.jl
+++ b/src/types.jl
@@ -22,7 +22,7 @@ end
 
 function getWireValue(arg::Union{Int32,Int64,Float32,Float64,UInt32,UInt64})
     opb = PipeBuffer()
-    ProtoBuf.write_fixed(opb, arg)
+    ProtoBuf.write_varint(opb, arg)
     return readavailable(opb)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,9 +20,15 @@ end
 
 #type helper functions
 
-function getWireValue(arg::Union{Int32,Int64,Float32,Float64,UInt32,UInt64})
+function getWireValue(arg::Integer)
     opb = PipeBuffer()
     ProtoBuf.write_varint(opb, arg)
+    return readavailable(opb)
+end
+
+function getWireValue(arg::AbstractFloat)
+    opb = PipeBuffer()
+    ProtoBuf.write_fixed(opb, arg)
     return readavailable(opb)
 end
 


### PR DESCRIPTION
Another set of bug fixes!

Closes #16
Closes #15
Closes #12

## Performance
- Set concrete type for singal channel 681571632dd76af0656c7690d1e138dc2f39d89a

## Code generation
- some functions were trying to use `this` when it does not exist. This should fix them. c8ac069b3a9d2a130e4256c3e39de9398d4bcea9. Closes #12
- add import for missing getJuliaValue, which some methods needed. 3a7828f601c33ba50e19a09da40ca1e418550c3c

## Bug fix
- error found during code review. Probably does not fix any real bug. 3a52bee1b496a5bdb115b26196b46bff0fd1999b
- use error instead of make_error that does not exist 1d775ba00485c397d8d5c9936d375cbc2a38f033 116f9a044294f228e0139004f24205eebd42d075. Closes #15, but it probably won't fix the originating exception on decoupling a separator.
- fix a bug preventing creating remote objects with ID higher than 127. Closes #16 6b72a4747f717c8ce3e827eefa66fcc3d2200090

